### PR TITLE
fixes bug with flatten

### DIFF
--- a/s20/sequences/diderot_interface.tex
+++ b/s20/sequences/diderot_interface.tex
@@ -340,20 +340,20 @@ Concatenate two sequences.
 \begin{flex}
 \label{grp:grm:seq-interface::flatten}
 
-\begin{gram}
-\label{grm:seq-interface::flatten}
 \begin{gram}[flatten]
-\label{gr:flatten}
+\label{grm:seq-interface::flatten}
 \begin{verbatim}
 val flatten : 'a seq seq -> 'a seq
 \end{verbatim}
 Concatenate many sequences into one, in the order they are given.
-\end{gram}
-\begin{example}
-Flattening $\cseq{\cseq{1,2},\cseq{},\cseq{3}}$ results in $\cseq{1,2,3}$.
-\end{example}
 
 \end{gram}
+
+\begin{example}
+\label{xmpl:seq-interface::flattening}
+Flattening $\cseq{\cseq{1,2},\cseq{},\cseq{3}}$ results in $\cseq{1,2,3}$.
+
+\end{example}
 \end{flex}
 
 \begin{cluster}

--- a/sequences/interface.tex
+++ b/sequences/interface.tex
@@ -1,3 +1,8 @@
+%% TODO:
+%%   - change labels so that they have the form
+%%     ch:seq-interface::<label>
+%%     That is, the chapter label is included in the label
+%%
 \chapter{Sequence Interface}
 \label{ch:seq-interface}
 \begin{preamble}
@@ -226,13 +231,15 @@ Concatenate two sequences.
 
 \begin{flex}
 \begin{gram}[flatten]
-\label{gr:flatten}
+\label{grm:seq-interface::flatten}
 \begin{verbatim}
 val flatten : 'a seq seq -> 'a seq
 \end{verbatim}
 Concatenate many sequences into one, in the order they are given.
 \end{gram}
+
 \begin{example}
+\label{xmpl:seq-interface::flattening}
 Flattening $\cseq{\cseq{1,2},\cseq{},\cseq{3}}$ results in $\cseq{1,2,3}$.
 \end{example}
 \end{flex}


### PR DESCRIPTION
flatten flex didn't have empty line between the two atoms (gram and example).  Put that in and put in labels so that the published chapter on diderot could be updated live.  Live update works, because we are adding atoms (the example atom) and not deleting an existing one.  